### PR TITLE
Make the implementation of skills as simple as possible

### DIFF
--- a/include/tick_server.h
+++ b/include/tick_server.h
@@ -22,9 +22,11 @@
 #include <atomic>
 
 #include <yarp/os/LogStream.h>
+#include <yarp/os/RFModule.h>
 
+using namespace yarp::os;
 
-class TickServer : public BTCmd
+class TickServer :  public BTCmd
 {
 public:
     TickServer();
@@ -39,13 +41,22 @@ public:
     // only when the status is either idle or halted, otherwise it will immediately return running.
     // Re-implement this function in case this helper logic is not required.
     virtual ReturnStatus request_tick(const std::string& params = "");
-    virtual ReturnStatus request_status() = 0;
-    virtual ReturnStatus request_halt()   = 0;
+
+
+    // implementation of Thrift command request_status
+    ReturnStatus request_status();
+
+    void set_status(ReturnStatus status);
+    ReturnStatus request_halt();
 
     // Request_tick will call this function when a meaningful tick is called, i.e. current status is
     // either idle or halted. If this implementation has blocking calls, set threaded to true in
     // the configuration.
     virtual ReturnStatus execute_tick(const std::string& params = "");
+
+    // execute the halt of the node
+    virtual void execute_halt();
+
 
     // Check if halt was requested by the BT engine
     bool getHalted();
@@ -62,8 +73,7 @@ private:
 
     bool threaded_ {false};
     std::thread execute_tick_thread_;
-    ReturnStatus status_;
-
+    std::atomic<ReturnStatus> status_;
     std::atomic<bool> is_halt_requested_;
 };
 

--- a/scenarios/blackboard_module.cpp
+++ b/scenarios/blackboard_module.cpp
@@ -25,7 +25,7 @@
 
 using namespace yarp::os;
 
-class BlackBoard : public RFModule, public TickServer
+class BlackBoard : public TickServer, public RFModule
 {
 
 private:
@@ -204,7 +204,7 @@ int main(int argc, char * argv[])
     blackboard.set("BottleGrasped", Value("False"));
     blackboard.set("InvPoseComputed", Value("False"));
     blackboard.set("InvPoseValid", Value("False"));
-    blackboard.set("InvPose", Value("False"));
+    blackboard.set("InvPose", Value("000000"));
 
 
     blackboard.runModule(rf);

--- a/scenarios/compute_inv_pose_module.cpp
+++ b/scenarios/compute_inv_pose_module.cpp
@@ -27,31 +27,29 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class ComputeInvPose : public RFModule, public TickServer
+class ComputeInvPose : public TickServer, public RFModule
 {
+private:
+    Bottle cmd, response;
+public:
+    yarp::os::Port blackboard_port;
+
 public:
     ReturnStatus execute_tick(const std::string& params = "") override
     {
+        set_status(BT_RUNNING);
 
-        //std::this_thread::sleep_for( std::chrono::seconds(3));
-        yInfo() << "requested tick with param " << params << " returning " << ret;
-        return ret;
-    }
-
-    ReturnStatus request_status()
-    {
-        ReturnStatus ret = BT_RUNNING;
-        ReturnStatusVocab a;
-        yInfo() << "request_status, replying with " << a.toString(ret);
-        return ret;
-    }
-
-    ReturnStatus request_halt()
-    {
-        ReturnStatus ret = BT_HALTED;
-        ReturnStatusVocab a;
-        yInfo() << "request_halt,  replying with " << a.toString(ret);
-        return ret;
+        yInfo() << "[ComputeInvPose] Action started";
+        std::string inv_pose = "123456";
+        cmd.clear();
+        response.clear();
+        cmd.addString("set");
+        cmd.addString("InvPose");
+        cmd.addString(inv_pose);
+        blackboard_port.write(cmd,response);
+        yInfo() << "ComputeInvPose InvPose is set to" << inv_pose;
+        set_status(BT_SUCCESS);
+        return BT_SUCCESS;
     }
 
     double getPeriod()
@@ -72,23 +70,6 @@ public:
         return true;
     }
 
-    bool configure(yarp::os::ResourceFinder &rf)
-   {
-        return true;
-   }
-
-    bool interruptModule()
-    {
-        return true;
-    }
-
-    // Close function, to perform cleanup.
-    bool close()
-    {
-        // optional, close port explicitly
-        return true;
-    }
-
 };
 
 int main(int argc, char * argv[])
@@ -106,12 +87,12 @@ int main(int argc, char * argv[])
 
     rf.configure(argc, argv);
 
-    moveJoint_module blackboard;
-    blackboard.configure_tick_server("/ComputeInvPose");
-
+    ComputeInvPose skill;
+    skill.configure_tick_server("/ComputeInvPose");
+    skill.blackboard_port.open("/ComputeInvPose/blackboard/rpc:o");
     // initialize blackboard
 
-    blackboard.runModule(rf);
+    skill.runModule(rf);
 
     return 0;
 }

--- a/scenarios/move_joints_module.cpp
+++ b/scenarios/move_joints_module.cpp
@@ -27,7 +27,7 @@
 using namespace yarp::os;
 using namespace yarp::dev;
 
-class moveJoint_module : public RFModule, public TickServer
+class moveJoint_module : public TickServer, public RFModule
 {
 private:
     PolyDriver  headDev;


### PR DESCRIPTION
HI, 
I made some minor edits (mostly shuffling code around) to make the implementation of a skill as simple as possible, in particular:

- RFModule dependency is now implicit
- get /set status is implemented in tick_server.cpp
- the methods to implement due to the extension of RFModule have a default implementation.

@barbalberto let me know if this makes sense to you.

Thanks
MC