### PR TITLE
Modifications of the LocateBottle leaf node to get object shape information

### DIFF
--- a/scenarios/locate_bottle_module.cpp
+++ b/scenarios/locate_bottle_module.cpp
@@ -31,6 +31,8 @@ class LocateBottle : public RFModule, public TickServer
 {
     RpcClient object_properties_collector_port; // should be connected to /memory/rpc
     RpcClient gaze_exploration_port; // should be connected to /iolStateMachineHandler/human:rpc
+    RpcClient point_cloud_read_port; // should be connected to /pointCloudRead/rpc
+    RpcClient find_superquadric_port; // should be connected to /find-superquadric/points:rpc
     RpcClient blackboard_port; // should be connected to /blackboard/rpc:i
 
     /****************************************************************/
@@ -116,6 +118,73 @@ class LocateBottle : public RFModule, public TickServer
         return true;
     }
 
+    /****************************************************************/
+    bool getObjectShape(const std::string &objectName, Vector &objectShape)
+    {
+        //connects to point-cloud-read and find-superquadric to retrieve the position, orientation and size of the object from the object name
+        //objectShape will be filled with (center_x center_y center_z rot_axis_x rot_axis_y rot_axis_z rot_angle size_axis_x size_axis_y size_axis_z)
+
+        if(point_cloud_read_port.getOutputCount()<1)
+        {
+            yError() << "getObjectProperties: no connection to point-cloud-read module";
+            return false;
+        }
+
+        if(find_superquadric_port.getOutputCount()<1)
+        {
+            yError() << "getObjectProperties: no connection to find-superquadric module";
+            return false;
+        }
+
+        Bottle cmd;
+        cmd.addString("get_point_cloud");
+        cmd.addString(objectName);
+
+        Bottle reply;
+        point_cloud_read_port.write(cmd, reply);
+
+        if(reply.size() < 1)
+        {
+            yError() << "getObjectProperties: empty reply from point-cloud-read:" << reply.toString();
+            return false;
+        }
+
+        PointCloud<DataXYZRGBA> pointCloud;
+        if(!pointCloud.fromBottle(*(reply.get(0).asList())))
+        {
+            yDebug() << "getObjectProperties: invalid reply from point-cloud-read:" << reply.toString();
+            return false;
+        }
+
+        reply.clear();
+        find_superquadric_port.write(pointCloud, reply);
+
+        Vector objectSuperquadric;
+        reply.write(objectSuperquadric);
+
+        if (objectSuperquadric.size() != 9)
+        {
+            yError() << "getObjectProperties: invalid reply from find-superquadric:" << reply.toString();
+            return false;
+        }
+
+        objectShape.resize(10);
+        objectShape[0] = objectSuperquadric[0];
+        objectShape[1] = objectSuperquadric[1];
+        objectShape[2] = objectSuperquadric[2];
+        objectShape[3] = 0.0;
+        objectShape[4] = 0.0;
+        objectShape[5] = 1.0;
+        objectShape[6] = M_PI/180*objectSuperquadric[3];
+        objectShape[7] = objectSuperquadric[4];
+        objectShape[8] = objectSuperquadric[5];
+        objectShape[9] = objectSuperquadric[6];
+
+        yInfo() << "Retrieved" << objectName << "shape:" << objectShape.toString();
+
+        return true;
+    }
+
     bool writeObjectPositionToBlackboard(const std::string &objectName, Vector &position)
     {
         if(position.size() != 3)
@@ -155,6 +224,49 @@ class LocateBottle : public RFModule, public TickServer
         }
 
         yInfo() << objectName+"Pose written to blackboard";
+
+        return true;
+    }
+
+    bool writeObjectShapeToBlackboard(const std::string &objectName, Vector &shape)
+    {
+        if(shape.size() != 10)
+        {
+            yError() << "writeObjectShapeToBlackboard: invalid shape vector dimension";
+            return false;
+        }
+
+        if(blackboard_port.getOutputCount()<1)
+        {
+            yError() << "writeObjectShapeToBlackboard: no connection to blackboard";
+            return false;
+        }
+
+        Bottle cmd;
+        cmd.addString("set");
+        cmd.addString(objectName+"Shape");
+        Bottle &subcmd = cmd.addList();
+        for(int i=0 ; i<10 ; i++)
+        {
+            subcmd.addDouble(shape[i]);
+        }
+
+        Bottle reply;
+        blackboard_port.write(cmd, reply);
+
+        if(reply.size() != 1)
+        {
+            yError() << "writeObjectShapeToBlackboard: invalid answer from blackboard: " << reply.toString();
+            return false;
+        }
+
+        if(reply.get(0).asInt() != 1)
+        {
+            yError() << "writeObjectShapeToBlackboard: invalid answer from blackboard: " << reply.get(0).toString();
+            return false;
+        }
+
+        yInfo() << objectName+"Shape written to blackboard";
 
         return true;
     }
@@ -314,9 +426,30 @@ class LocateBottle : public RFModule, public TickServer
             return BT_HALTED;
         }
 
+        Vector objectShape;
+        if(!this->getObjectShape(objectName, objectShape))
+        {
+            yError()<<"execute_tick: getObjectShape failed";
+            this->set_status(BT_FAILURE);
+            return BT_FAILURE;
+        }
+
+        if(this->getHalted())
+        {
+            this->set_status(BT_HALTED);
+            return BT_HALTED;
+        }
+
         if(!this->writeObjectPositionToBlackboard(objectName, position3D))
         {
             yError()<<"execute_tick: writeObjectPositionToBlackboard failed";
+            this->set_status(BT_FAILURE);
+            return BT_FAILURE;
+        }
+
+        if(!this->writeObjectShapeToBlackboard(objectName, objectShape))
+        {
+            yError()<<"execute_tick: writeObjectShapeToBlackboard failed";
             this->set_status(BT_FAILURE);
             return BT_FAILURE;
         }
@@ -353,6 +486,20 @@ class LocateBottle : public RFModule, public TickServer
            return false;
         }
 
+        std::string pointCloudReadPortName= "/"+this->getName()+"/pointCloudRead/rpc:o";
+        if (!point_cloud_read_port.open(pointCloudReadPortName))
+        {
+           yError() << this->getName() << ": Unable to open port " << pointCloudReadPortName;
+           return false;
+        }
+
+        std::string findSuperquadricPortName= "/"+this->getName()+"/findSuperquadric/rpc:o";
+        if (!find_superquadric_port.open(findSuperquadricPortName))
+        {
+           yError() << this->getName() << ": Unable to open port " << findSuperquadricPortName;
+           return false;
+        }
+
         std::string blackboardPortName= "/"+this->getName()+"/blackboard/rpc:o";
         if (!blackboard_port.open(blackboardPortName))
         {
@@ -386,6 +533,8 @@ class LocateBottle : public RFModule, public TickServer
     {
         object_properties_collector_port.interrupt();
         gaze_exploration_port.interrupt();
+        point_cloud_read_port.interrupt();
+        find_superquadric_port.interrupt();
         blackboard_port.interrupt();
 
         return true;
@@ -396,6 +545,8 @@ class LocateBottle : public RFModule, public TickServer
     {
         object_properties_collector_port.close();
         gaze_exploration_port.close();
+        point_cloud_read_port.close();
+        find_superquadric_port.close();
         blackboard_port.close();
 
         return true;


### PR DESCRIPTION
The LocateBottle module now also find the position, orientation and size of the object and writes it to the blackboard.
The module can now be used for the LocateGlass leaf node and the modifications are mostly intended for use by the pouring module.

It requires two new connections:
- from `/LocateBottle/pointCloudRead/rpc:o` to `/pointCloudRead/rpc`
- from `/LocateBottle/findSuperquadric/rpc:o` to `/find-superquadric/points:rpc`

The call to the node is still the same: `request_tick "<objectName> <timeout>"`.

It then writes a new vector variable to the blackboard called `<objectName>Shape`and containing the position, orientation and size of the object (format is (center_x center_y center_z rot_axis_x rot_axis_y rot_axis_z rot_angle size_axis_x size_axis_y size_axis_z)).